### PR TITLE
Fix scratch dir

### DIFF
--- a/bin/start
+++ b/bin/start
@@ -43,4 +43,10 @@ sed -i "s/REPLACE_TIME/$START_TIME/" slurm/jobs/"job_${START_TIME}.txt"
 # Mail at end and error of analysis to bioinformatician
 # Specified time, calculated by check.py
 # Send error and output to slurm log
-sbatch --mail-type END,ERROR --mail-user $(cat .email_bioinformatician) --time "$NR_MINUTES" --output "slurm/slurm_logs/${START_TIME}/job_%j_%u.out" --error "slurm/slurm_logs/${START_TIME}/job_%j_%u.err" slurm/jobs/"job_${START_TIME}.txt"
+sbatch \
+  --mail-type END,ERROR \
+  --mail-user $(cat .email_bioinformatician) \
+  --time "$NR_MINUTES" \
+  --output "slurm/slurm_logs/${START_TIME}/job_%j_%u.out" \
+  --error "slurm/slurm_logs/${START_TIME}/job_%j_%u.err" \
+  slurm/jobs/"job_${START_TIME}.txt"

--- a/workflow/assembly.smk
+++ b/workflow/assembly.smk
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 # This defines the file containing configurations
 # These values can be accessed through config[entry]
 # See https://yaml.org/ for explanation of the YAML format
@@ -10,7 +12,7 @@ configfile: "workflow/config/config.yaml"
 # Zip and join together all sample names and numbers. This will be used later on to find files to remove 
 SAMPLE_NAMES_NUMBERS = ['_'.join([samplenumber, samplename]) for samplenumber, samplename in zip(SAMPLE_NUMBERS, SAMPLE_NAMES)]
 
-SCRATCH_DIR = config["scratch_dir"]
+SCRATCH_DIR = Path(config["scratch_dir"])
 
 # Define the desired output of the pipeline 
 rule all:

--- a/workflow/job_template.txt
+++ b/workflow/job_template.txt
@@ -45,18 +45,18 @@ snakemake -s workflow/typing.smk --config timestamp="$TIMESTAMP" -j 16 --use-con
 
 NR_LINES_NMEN_QC_REPORT=$(wc -l "backup/${TIMESTAMP}/qc_report_nmen.tsv" | awk '{print $1}')
 
-if [[ "$NR_LINES_NMEN_QC_REPORT" -gt 1 ]]
-then
-  # Clustering snakemake command
-  snakemake -s workflow/clustering.smk --config timestamp="$TIMESTAMP" -j 16 --use-conda --latency-wait 60 --printshellcmds --stats "backup/${TIMESTAMP}/stats_clustering_${TIMESTAMP}.json" --notemp
+# if [[ "$NR_LINES_NMEN_QC_REPORT" -gt 1 ]]
+# then
+#   # Clustering snakemake command
+#   snakemake -s workflow/clustering.smk --config timestamp="$TIMESTAMP" -j 16 --use-conda --latency-wait 60 --printshellcmds --stats "backup/${TIMESTAMP}/stats_clustering_${TIMESTAMP}.json" --notemp
 
-  # Snakemake command to create report in backup folder
-  snakemake -s workflow/clustering.smk --config timestamp="$TIMESTAMP" -j 16 --use-conda --report "backup/${TIMESTAMP}/report_clustering_${TIMESTAMP}.html"
+#   # Snakemake command to create report in backup folder
+#   snakemake -s workflow/clustering.smk --config timestamp="$TIMESTAMP" -j 16 --use-conda --report "backup/${TIMESTAMP}/report_clustering_${TIMESTAMP}.html"
 
-  # Run script to prepare PubMLST upload folder
-  mkdir -p "output/${TIMESTAMP}/pubmlst_upload"
-  python workflow/scripts/prepare_pubmlst.py -m metadata_pubmlst/metadata_pubmlst.csv --qc "backup/${TIMESTAMP}/qc_report_nmen.tsv" -o "output/${TIMESTAMP}/pubmlst_upload" --input "output/${TIMESTAMP}/genomes" 2>"output/${TIMESTAMP}/pubmlst_upload/logfile.txt"
-fi
+#   # Run script to prepare PubMLST upload folder
+#   mkdir -p "output/${TIMESTAMP}/pubmlst_upload"
+#   python workflow/scripts/prepare_pubmlst.py -m metadata_pubmlst/metadata_pubmlst.csv --qc "backup/${TIMESTAMP}/qc_report_nmen.tsv" -o "output/${TIMESTAMP}/pubmlst_upload" --input "output/${TIMESTAMP}/genomes" 2>"output/${TIMESTAMP}/pubmlst_upload/logfile.txt"
+# fi
 
 # Remove all files listed in list_files_to_remove.txt
 while read file

--- a/workflow/job_template.txt
+++ b/workflow/job_template.txt
@@ -12,10 +12,25 @@ TIMESTAMP=REPLACE_TIME
 mkdir -p "backup/${TIMESTAMP}"
 
 # Main snakemake command, writing stats to backup folder
-snakemake -s workflow/assembly.smk --config timestamp="$TIMESTAMP" -j 16 --use-conda --latency-wait 60 --printshellcmds --stats "backup/${TIMESTAMP}/stats_${TIMESTAMP}.json"
+# TMPDIR var is different per job and is set by slurm
+snakemake \
+  -s workflow/assembly.smk \
+  --config timestamp="$TIMESTAMP" \
+  --config scratch_dir="$TMPDIR" \
+  -j 16 \
+  --use-conda \
+  --latency-wait 60 \
+  --printshellcmds \
+  --stats "backup/${TIMESTAMP}/stats_${TIMESTAMP}.json"
 
 # Snakemake command to create report in backup folder
-snakemake -s workflow/assembly.smk --config timestamp="$TIMESTAMP" -j 16 --use-conda --report "backup/${TIMESTAMP}/report_${TIMESTAMP}.html"
+snakemake \
+  -s workflow/assembly.smk \
+  --config timestamp="$TIMESTAMP" \
+  --config scratch_dir="$TMPDIR" \
+  -j 16 \
+  --use-conda \
+  --report "backup/${TIMESTAMP}/report_${TIMESTAMP}.html"
 
 # Perform QC
 python workflow/scripts/qc.py --species "Escherichia coli" --timestamp "$TIMESTAMP" --output "backup/${TIMESTAMP}/qc_report_ecoli.tsv"


### PR DESCRIPTION
Instead of using hardcoded `/scratch` which was available for jobs running on Lisa, the pipeline now:

- sets a Snakemake config value `scratch_dir` to the job-specific path stored in `$TMPDIR` when a job starts (in `job_template.txt`)
- in `assembly.smk`, sets this path to a Python variable `SCRATCH_DIR`
- uses the `SCRATCH_DIR` variable to copy read files to appropriate scratch location